### PR TITLE
No cache, reduce size + various small changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,26 @@
 FROM alpine
 
 ENV alpine_rakudo_apk_url=https://github.com/nxadm/rakudo-pkg/releases/download/v2012.12-02/rakudo-pkg-Alpine3.10_2020.12-02_x86_64.apk
-
 ENV PATH=/opt/rakudo-pkg/share/perl6/site/bin:/opt/rakudo-pkg/bin:/root/.raku/bin:$PATH
 
-RUN apk update --wait 120 && \ 
-    apk add --wait 120 curl perl bash git && \
-    curl -s -L -k -o /tmp/rakudo-pkg.apk \
-    $alpine_rakudo_apk_url  && \
-    apk add --allow-untrusted /tmp/rakudo-pkg.apk
-
-RUN apk add sqlite  sqlite-libs  sqlite-dev procps openssh-client
+RUN apk add --no-cache curl perl bash git && \
+    curl -s -L -k -o /tmp/rakudo-pkg.apk $alpine_rakudo_apk_url && \
+    apk add --allow-untrusted /tmp/rakudo-pkg.apk && \
+    apk add --no-cache sqlite sqlite-libs sqlite-dev procps openssh-client && \
+    rm /tmp/rakudo-pkg.apk
 
 RUN mkdir -p /root/.sparky/
-
 ENV BAILADOR=host:0.0.0.0,port:3000
 
-RUN zef install https://github.com/melezhik/Sparrow6.git --test
+RUN zef install --/test https://github.com/melezhik/Sparrow6.git && \
+    rm /root/.zef/* -R
 
-RUN zef install https://github.com/melezhik/sparrowdo.git --test
-
-RUN zef install https://github.com/melezhik/sparky.git --/test
+RUN zef install --/test https://github.com/melezhik/sparrowdo.git \
+    https://github.com/melezhik/sparky.git && \
+    rm /root/.zef/* -R
 
 RUN git clone https://github.com/melezhik/sparky.git /root/sparky
-
 COPY entrypoint.sh  /tmp/
-
-#RUN echo "PATH=$PATH" >> $ENV
 
 ENTRYPOINT bash /tmp/entrypoint.sh
 


### PR DESCRIPTION
Use --no-cache. Remove Raku module manager caching. Gather zef statements as much as I can (for now). Remove rakudo apk package after install. The overall thing reduces size of final image.

I do not gathered all zef lines because there is a problem in dependencies resolving.
This 3 lines one after the others are working OK : 
```bash
$ zef install --/test https://github.com/melezhik/Sparrow6.git
$ zef install --/test https://github.com/melezhik/sparrowdo.git
$ zef install --/test https://github.com/melezhik/sparky.git
```

But gathering all in one ends in error ( "Failed to resolve some missing dependencies"): 
```bash
$ zef install --/test https://github.com/melezhik/Sparrow6.git https://github.com/melezhik/sparrowdo.git https://github.com/melezhik/sparky.git
```

Because sparky requires Data::Dump:ver<2.0.0+> when Sparrow6 requires Data::Dump:ver<1.0.0>

`--no-cache` is forcing `apk update` but does not requires to `rm /var/apk/cache/*` that was not in the Dockerfile anyway :D 

I took the liberty to also drop a comment and some empty lines.
